### PR TITLE
Allow direct paths to be used for the tokengen URL.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "iamus-metaverse-server",
-    "version": "2.2.8",
+    "version": "2.2.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "iamus-metaverse-server",
-    "version": "2.2.6",
+    "version": "2.2.8",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -47,8 +47,8 @@ export let Config = {
       'session-timeout-minutes': 5,
       'connection-request-expiration-minutes': 1,
       'friend-request-expiration-minutes': 60 * 24 * 4,
-      // redirection URL used for initial domain token generation
-      'tokengen_url': '/static/DomainTokenLogin.html',
+      // redirection URL used for initial domain token generation, use "METAVERSE_SERVER_URL" as a base if using the static folder.
+      'tokengen_url': 'METAVERSE_SERVER_URL/static/DomainTokenLogin.html',
       // When account of this name is created, add 'admin' role to it
       'base-admin-account': 'adminer'
     },

--- a/src/routes/user/tokens/new.ts
+++ b/src/routes/user/tokens/new.ts
@@ -37,7 +37,11 @@ const procGetUserTokensNew: RequestHandler = async (req: Request, resp: Response
   else {
     // if the user is not logged in, go to a page to login and set things up
     resp.statusCode = HTTPStatusCode.Found;
-    resp.setHeader('Location', Config.metaverse["metaverse-server-url"] + Config["metaverse-server"].tokengen_url),
+    if (Config["metaverse-server"].tokengen_url.startsWith('/')) {
+        resp.setHeader('Location', Config.metaverse["metaverse-server-url"] + Config["metaverse-server"].tokengen_url);
+    } else {
+        resp.setHeader('Location', Config["metaverse-server"].tokengen_url);
+    }
     resp.setHeader('content-type', 'text/html');
     resp.send();
   };

--- a/src/routes/user/tokens/new.ts
+++ b/src/routes/user/tokens/new.ts
@@ -36,12 +36,10 @@ const procGetUserTokensNew: RequestHandler = async (req: Request, resp: Response
   }
   else {
     // if the user is not logged in, go to a page to login and set things up
+    const tokengen_url = Config["metaverse-server"].tokengen_url.replace('METAVERSE_SERVER_URL', Config.metaverse["metaverse-server-url"]);
+
     resp.statusCode = HTTPStatusCode.Found;
-    if (Config["metaverse-server"].tokengen_url.startsWith('/')) {
-        resp.setHeader('Location', Config.metaverse["metaverse-server-url"] + Config["metaverse-server"].tokengen_url);
-    } else {
-        resp.setHeader('Location', Config["metaverse-server"].tokengen_url);
-    }
+    resp.setHeader('Location', tokengen_url);
     resp.setHeader('content-type', 'text/html');
     resp.send();
   };


### PR DESCRIPTION
This hasn't been tested though, haven't setup Mongo or anything on my local Windows machine. Also originally it had a comma at the end, why?